### PR TITLE
Change export order of modules

### DIFF
--- a/packages/sidebar2020/lib/modules/index.js
+++ b/packages/sidebar2020/lib/modules/index.js
@@ -1,11 +1,11 @@
 export * from './users/index.js';
 export * from './categories/index.js';
 export * from './posts/index.js';
-export * from './newsletters/index.js';
-export * from './jobs/index.js';
 export * from './discounts/index.js';
-export * from './charges/index.js';
+export * from './jobs/index.js';
 export * from './logs/index.js';
+export * from './newsletters/index.js';
+export * from './charges/index.js';
 export * from './blog/index.js';
 export * from './sites/index.js';
 


### PR DESCRIPTION
This small changes solve runtime errors like: `JobsFragment not initialized`


